### PR TITLE
Style invalidation due to change of class name

### DIFF
--- a/styles/code.styl
+++ b/styles/code.styl
@@ -1,6 +1,6 @@
 @require './config'
 
-.content
+.content, .content__default
   :not(pre)>code
     color lighten($textColor, 20%)
     padding 0.25rem 0.5rem
@@ -16,7 +16,7 @@
     background-color rgba(27,31,35,0.05)
     border-radius 3px
 
-.content
+.content, .content__default
   pre, pre[class*="language-"]
     background-color $codeBgColor
     line-height 1.4

--- a/styles/mobile.styl
+++ b/styles/mobile.styl
@@ -7,7 +7,7 @@ $mobileSidebarWidth = $sidebarWidth * 0.8
   .sidebar
     font-size 15px
     width $mobileSidebarWidth
-  .content:not(.custom)
+  .content:not(.custom), .content__default:not(.custom)
     padding 2rem
   .content-header
     padding 0 2rem
@@ -27,9 +27,9 @@ $mobileSidebarWidth = $sidebarWidth * 0.8
 @media (max-width: $MQMobileNarrow)
   h1
     font-size 1.9rem
-  .content:not(.custom)
+  .content:not(.custom), .content__default:not(.custom)
     padding 1.5rem
-  .content
+  .content, .content__default
     pre, pre[class*="language-"]
       margin 0.85rem -1.5rem
       border-radius 0

--- a/styles/theme.styl
+++ b/styles/theme.styl
@@ -17,7 +17,7 @@ body
   color $textColor
   background #e6ecf0
 
-.content:not(.custom)
+.content:not(.custom), .content__default:not(.custom)
   max-width $contentWidth
   margin 0 auto
   padding 2rem 2.5rem
@@ -37,7 +37,7 @@ body
   margin 0 auto
   padding 0 2rem
 
-.content.custom
+.content.custom, .content__default.custom
   padding 0
   margin 0
 
@@ -73,7 +73,7 @@ strong
 h1, h2, h3, h4, h5, h6
   font-weight 600
   line-height 1.25
-  .content:not(.custom) > &
+  .content:not(.custom) > &, .content__default:not(.custom) > &
     margin-top (0.5rem - $navbarHeight)
     padding-top ($navbarHeight + 1rem)
     margin-bottom 0


### PR DESCRIPTION
Style invalidation due to change of class name in vuepress(v1.0.0-alpha.49)
Reference: [https://github.com/vuejs/vuepress/commit/7d0542e33e979576dc5312faf8d638d424cdb1ec](https://github.com/vuejs/vuepress/commit/7d0542e33e979576dc5312faf8d638d424cdb1ec)